### PR TITLE
Fix memory leak when removing a socket not joined to any room

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,11 +88,10 @@ Adapter.prototype.get = function get(id, fn) {
 };
 
 /**
- * Remove a socket from a room or from all rooms
- * if a room is not passed.
+ * Remove a socket from a room or from all rooms if a room is not passed.
  *
  * @param {String} id Socket id
- * @param {String} [room] The room name
+ * @param {String} room The room name
  * @param {Function} [fn] Callback
  * @api public
  */
@@ -102,14 +101,10 @@ Adapter.prototype.del = function del(id, room, fn) {
     , ids = this.sids
     , rooms = this.rooms;
 
-  ids[id] = ids[id] || {};
-
   if (room) {
-    rooms[room] = rooms[room] || {};
-
     if (this.wildDelete && ~room.indexOf('*')) {
       adapter.wildcard.find(room, this.get(id), prune);
-    } else {
+    } else if (ids[id] && ids[id][room]) {
       prune(room);
     }
   } else {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "eventemitter3": "1.1.x",
+    "eventemitter3": "1.2.x",
     "extendible": "0.1.x"
   },
   "devDependencies": {
-    "expect.js": "*",
-    "mocha": "*",
+    "expect.js": "^0.3.1",
+    "mocha": "^2.5.3",
     "pre-commit": "^1.1.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -16,4 +16,13 @@ describe('primus-rooms-adapter', function () {
     expect(adapter.clear).to.be.a('function');
     expect(adapter.wildcard).to.be.an('object');
   });
+
+  describe('Adapter#del', function () {
+    it('should not leak memory', function () {
+      var adapter = new Adapter();
+      adapter.del('foo');
+      expect(adapter.rooms).to.eql({});
+      expect(adapter.sids).to.eql({});
+    });
+  });
 });


### PR DESCRIPTION
A memory leak is created when a socket, not connected to any room, is removed from all rooms.
An empty object is assigned to [`ids[id]`](https://github.com/cayasso/primus-rooms-adapter/blob/23cbf07da73b47d1856ae8a088d00e78c36ce76b/lib/index.js#L105) and never cleaned up because the [`for`](https://github.com/cayasso/primus-rooms-adapter/blob/23cbf07da73b47d1856ae8a088d00e78c36ce76b/lib/index.js#L116) loop is empty.

This patch should fix the issue.