### PR TITLE
Forward possible errors when cloning data to the socket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,11 @@ Adapter.prototype.transform = function transform(socket, data, method, transform
     return send();
   }
 
-  packet = { data: clone(data) };
+  try {
+    packet.data = JSON.parse(JSON.stringify(data));
+  } catch (e) {
+    return socket.emit('error', e);
+  }
 
   if (1 === transformer.length) {
     if (false === transformer.call(socket, packet)) return;
@@ -301,22 +305,6 @@ Adapter.prototype.use = function use(plugin) {
   args.unshift(this);
   plugin.apply(this, args);
 };
-
-/**
- * Clone an object.
- *
- * @param {Mixed} data Data to clone
- * @return {Mixed} Cloned data
- * @api private
- */
-
-function clone(data) {
-  try {
-    return JSON.parse(JSON.stringify(data));
-  } catch (e) {
-    console.error(e);
-  }
-}
 
 // Make adapter extendable.
 Adapter.extend = extend;


### PR DESCRIPTION
I think it makes sense to forward the errors to the spark instead of logging them to the console.