### PR TITLE
Replace `process.nextTick` with `setImmediate`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ Adapter.prototype.set = function set(id, room, fn) {
   this.rooms[room] = this.rooms[room] || {};
   this.rooms[room][id] = true;
   this.wildcard.add(room);
-  if (fn) process.nextTick(fn.bind(null, null));
+  if (fn) setImmediate(fn, null);
 };
 
 /**
@@ -69,9 +69,7 @@ Adapter.prototype.set = function set(id, room, fn) {
 Adapter.prototype.get = function get(id, fn) {
   var rooms = id ? this.sids[id] || {} : this.rooms;
   rooms = Object.keys(rooms);
-  if (fn) process.nextTick(function tick() {
-    fn(null, rooms);
-  });
+  if (fn) setImmediate(fn, null, rooms);
   return rooms;
 };
 
@@ -99,7 +97,7 @@ Adapter.prototype.del = function del(id, room, fn) {
     for (room in ids[id]) prune(room);
   }
 
-  if (fn) process.nextTick(fn.bind(null, null));
+  if (fn) setImmediate(fn, null);
 
   function prune(room) {
     delete ids[id][room];
@@ -217,9 +215,7 @@ Adapter.prototype.clients = function clients(room, fn) {
   var _room = this.rooms[room]
     , ids = _room ? Object.keys(_room) : [];
 
-  if (fn) process.nextTick(function tick() {
-    fn(null, ids);
-  });
+  if (fn) setImmediate(fn, null, ids);
   return ids;
 };
 
@@ -247,7 +243,7 @@ Adapter.prototype.empty = function empty(room, fn) {
     clear(room);
   }
 
-  if (fn) process.nextTick(fn.bind(null, null));
+  if (fn) setImmediate(fn, null);
 
   function clear(room) {
     for (var id in rooms[room]) delete ids[id][room];
@@ -268,9 +264,7 @@ Adapter.prototype.empty = function empty(room, fn) {
 Adapter.prototype.isEmpty = function isEmpty(room, fn) {
   var ids = this.rooms[room];
 
-  if (fn) process.nextTick(function tick() {
-    fn(null, !ids);
-  });
+  if (fn) setImmediate(fn, null, !ids);
   return !ids;
 };
 
@@ -285,7 +279,7 @@ Adapter.prototype.isEmpty = function isEmpty(room, fn) {
 Adapter.prototype.clear = function empty(fn) {
   this.rooms = {};
   this.sids = {};
-  if (fn) process.nextTick(fn.bind(null, null));
+  if (fn) setImmediate(fn, null);
   return this;
 };
 


### PR DESCRIPTION
Primus no longer supports node 0.8 so I guess it's safe to land this also on the `0.x` line.
The crash is deserved if someone is still using node 0.8.
