### PR TITLE
[doc] Added missing information for get API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Adds a socket to a room.
 
 ### adapter.get(id, fn)
 
-Get rooms socket is subscribed to.
+Get rooms socket is subscribed to or get all rooms in the server if an id is not passed.
 
 ### adapter.del(id, room, fn)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var primus = new Primus(url, {
 
 ## API (Abstract public methods).
 
-### adapter.set(id, room, fn)
+### adapter.add(id, room, fn)
 
 Adds a socket to a room.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ Adapter.prototype.set = function set(id, room, fn) {
 };
 
 /**
- * Get rooms socket is subscribed to.
+ * Get rooms socket is subscribed to or get all rooms in the server if an id is not passed.
  *
  * @param {String} id Socket id
  * @param {Function} [fn] Callback


### PR DESCRIPTION
Updated readme documentation as well as the JSDoc to match the code's behavior for get.
Also updated the readme to use add instead of set since **primus-rooms** uses add instead of set. This results in falling back to in-memory adapter add for people who built a set API causing confusion and issues.